### PR TITLE
Adicionar serviço de upload de arquivos

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace App\Providers;
 
+use App\Services\UploadService;
 use Illuminate\Support\ServiceProvider;
 
 class AppServiceProvider extends ServiceProvider
@@ -11,7 +12,9 @@ class AppServiceProvider extends ServiceProvider
      */
     public function register(): void
     {
-        //
+        $this->app->singleton(UploadService::class, function () {
+            return new UploadService();
+        });
     }
 
     /**

--- a/app/Services/UploadService.php
+++ b/app/Services/UploadService.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Services;
+
+use Illuminate\Http\UploadedFile;
+
+class UploadService
+{
+    /**
+     * Upload a file.
+     *
+     * @param UploadedFile $file
+     * @return string
+     * @throws \Exception
+     */
+    public function uploadFile(UploadedFile $file): string
+    {
+        if ($file->getSize() > 300 * 1024 * 1024) {
+            throw new \Exception('File size must not exceed 300MB.');
+        }
+
+        if ($file->getClientMimeType() !== 'application/json') {
+            throw new \Exception('Only JSON files are allowed.');
+        }
+
+        $path = $file->store('uploads', 'public');
+
+        return $path;
+    }
+}


### PR DESCRIPTION
# Descrição da Pull Request

## Objetivo

Esta Pull Request tem como objetivo adicionar um serviço de upload de arquivos à aplicação Laravel. O serviço permite o upload de arquivos JSON com tamanho máximo de 300MB.

## Alterações Realizadas

1. **Criação do Service `UploadService`**:
   - Adicionado o serviço `UploadService` para lidar com a lógica de upload de arquivos.
   - O serviço verifica o tamanho do arquivo (máximo de 300MB) e o tipo MIME (apenas arquivos JSON são permitidos).

### UploadService

- Verifica o tamanho do arquivo (máximo de 300MB).
- Verifica o tipo MIME do arquivo (apenas arquivos JSON são permitidos).
- Armazena o arquivo no diretório `uploads` dentro do disco `public`.

## Considerações Finais

Estas alterações adicionam a funcionalidade de upload de arquivos à aplicação, permitindo o upload de arquivos JSON com tamanho máximo de 300MB. O serviço de upload garante que apenas arquivos válidos sejam aceitos, melhorando a robustez e a segurança da aplicação.